### PR TITLE
[WIP] rough draft of python download function

### DIFF
--- a/pulp_migrate/constants.py
+++ b/pulp_migrate/constants.py
@@ -4,4 +4,6 @@ PYTHON_REPO = 'pypi'
 PUPPET_REPO = 'puppetforge'
 DOCKER_V1_REPO = 'dockerv1'
 DOCKER_V2_REPO = 'dockerv2'
-PYTHON_PYPI_PACKAGES = 'shelf-reader'
+PYTHON_PYPI_PACKAGE_NAME = 'shelf-reader'
+ALL_PYTHON_PYPI_PACKAGES = ['shelf-reader-0.1.tar.gz', 'shelf_reader-0.1-py2-none-any.whl']
+LEGACY_PYTHON_PYPI_PACKAGES = [ALL_PYTHON_PYPI_PACKAGES[0]]

--- a/pulp_migrate/test_restore.py
+++ b/pulp_migrate/test_restore.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 import unittest
 
-from pulp_smash import api, utils, config
+from pulp_smash import api, utils, config, selectors
 from pulp_smash.constants import (
     REPOSITORY_PATH,
     RPM,
@@ -15,9 +15,15 @@ from pulp_migrate.constants import (
     PYTHON_REPO,
     DOCKER_V1_REPO,
     DOCKER_V2_REPO,
+    PYTHON_PYPI_PACKAGE_NAME,
+    ALL_PYTHON_PYPI_PACKAGES,
+    LEGACY_PYTHON_PYPI_PACKAGES,
 )
 
-from pulp_migrate.utils import download_rpm
+from pulp_migrate.utils import (
+    download_rpm,
+    download_python_package,
+)
 
 
 class BaseRestoreTestCase(unittest.TestCase):
@@ -69,6 +75,16 @@ class TestPythonRepo(BaseRestoreTestCase):
         api.poll_spawned_tasks(self.cfg, sync_report.json())
         units = utils.search_units(self.cfg, repo)
         self.assertGreater(len(units), 0, 'No units found in repo')
+        if selectors.bug_is_testable(1883, self.cfg.version):
+            download_python_package(
+                PYTHON_REPO,
+                PYTHON_PYPI_PACKAGE_NAME,
+                ALL_PYTHON_PYPI_PACKAGES)
+        else:
+            download_python_package(
+                PYTHON_REPO,
+                PYTHON_PYPI_PACKAGE_NAME,
+                LEGACY_PYTHON_PYPI_PACKAGES)
 
 
 class TestDockerRepo(BaseRestoreTestCase):

--- a/pulp_migrate/utils.py
+++ b/pulp_migrate/utils.py
@@ -67,3 +67,21 @@ def clean_repo(repo_id):
         if urljoin(REPOSITORY_PATH, repo_id) in repo['_href']:
             client.delete(repo['_href'])
     client.delete(ORPHANS_PATH)
+
+def download_python_package(repo_name, package_name, packages):
+    """Download all items listed under python package.
+
+    Note: packages MUST be a list
+    """
+    PYTHON_PUBLISHED_PATH = '/pulp/python/web'
+    PACKAGE_URL = '{}/{}/packages/source/{}/{}'.format(
+        PYTHON_PUBLISHED_PATH,
+        repo_name,
+        package_name[0],
+        package_name
+    )
+    client = api.Client(config.get_config(), api.safe_handler)
+    responses = []
+    for package in packages:
+        responses += client.get('{}/{}'.format(PACKAGE_URL, package))
+    return responses


### PR DESCRIPTION
@Ichimonji10 

This is a _very_ rough draft of a python downloader.

It just manually forms the download path based on constants that record the package names (of actual .whl, .tar.gz, etc files).

An alternative would be to actually parse the html from hitting `/pulp/python/web/${REPONAME}/simple/${PACKAGENAME}`

```
 http --verify no -a 'admin:admin' GET https://localhost/pulp/python/web/pypi/simple/shelf-reader/
HTTP/1.1 200 OK
Accept-Ranges: bytes
Connection: Keep-Alive
Content-Length: 712
Content-Type: text/html; charset=UTF-8
Date: Wed, 16 Aug 2017 19:41:45 GMT
ETag: "2c8-556e4079c0413"
Keep-Alive: timeout=5, max=10000
Last-Modified: Wed, 16 Aug 2017 19:37:43 GMT
Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_wsgi/3.4 Python/2.7.5

<?xml version='1.0' encoding='utf8'?>
<html><head><title>Links for shelf-reader</title><meta name="api-version" value="2" /></head><body><h1>Links for shelf-reader</h1><a href="../../packages/source/s/shelf-reader/shelf_reader-0.1-py2-none-any.whl#sha512=1e38ac80980094ea9bb36a3ab9cb31476ac96c7839789caaf99f6bd170c1c12dd802f46270e25f1352380f40fac8f62ef85ddc0ca03bf25922c18a4b1ee04187" rel="internal">shelf_reader-0.1-py2-none-any.whl</a><br /><a href="../../packages/source/s/shelf-reader/shelf-reader-0.1.tar.gz#sha512=4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f" rel="internal">shelf-reader-0.1.tar.gz</a><br /></body></html>
```

The relative paths leave something to be desired.

Below is some doodling I did with parsing the html.
```
In [21]: from html.entities import name2codepoint
    ...: from html.parser import HTMLParser
    ...: 
    ...: class PackageParser(HTMLParser):
    ...:     def __init__(self):
    ...:         HTMLParser.__init__(self)
    ...:         self.attributes = []
    ...:    
    ...:     def handle_starttag(self, tag, attrs):
    ...:         for attr in attrs:
    ...:             self.attributes.append(attr)
    ...: 
    ...: pp = PackageParser()
    ...: 
In [36]: client = api.Client(config.get_config(), api.safe_handler)

In [37]: response = client.get('/pulp/python/web/pypi/simple/shelf-reader/')
/usr/lib/python3.5/site-packages/requests/packages/urllib3/connectionpool.py:821: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)

In [38]: pp.feed(data=str(response.content))

In [39]: pp.attributes
Out[39]: 
[('name', 'api-version'),
 ('value', '2'),
 ('href',
  '../../packages/source/s/shelf-reader/shelf-reader-0.1.tar.gz#sha512=4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f'),
 ('rel', 'internal'),
 ('name', 'api-version'),
 ('value', '2'),
 ('href',
  '../../packages/source/s/shelf-reader/shelf-reader-0.1.tar.gz#sha512=4d11d6a67ec6aa3eb25df2416b6d48f1c6c04d5e745b12d7dbc89aacfc8bcb439c5ccff56324ce8493099e4e2f79a414d2513758782efcaef84b3d8cf00ea45f'),
 ('rel', 'internal')]

```
[EDIT: Updated all above to be with same host. While I had updated my settings.json I had not re-queried the config.get_config()]

Any thoughts?

I've used this on a 2.11 install on rhel6 with the pulp-migrate populate content and a 2.13 install on rhel7 with the restored content from backing up the rhel6 machine.